### PR TITLE
Extend API to support basic (random) "scheduler", and add tree fields

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ markdown = "*"
 django-filter = "*"
 requests = "*"
 ipython = "*"
+django-cors-headers = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ djangorestframework = "*"
 markdown = "*"
 django-filter = "*"
 requests = "*"
+ipython = "*"
 
 [requires]
 python_version = "3.6"

--- a/alignmentpro/alignmentpro/settings.py
+++ b/alignmentpro/alignmentpro/settings.py
@@ -139,7 +139,9 @@ REST_FRAMEWORK = {
     # or allow read-only access for unauthenticated users.
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly"
-    ]
+    ],
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 20,
 }
 
 

--- a/alignmentpro/alignmentpro/settings.py
+++ b/alignmentpro/alignmentpro/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     "treebeard",  # for TreeAdmin views
     "alignmentapp",
     # 'commonstandardsproject',   # tmp to extract CCSS and NGSS data
+    "corsheaders",
     "importing",
     "django_extensions",
 ]
@@ -48,6 +49,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -151,3 +153,9 @@ CURRICULUM_DOCUMENTS_FILENAME = "curriculumdocuments.csv"
 STANDARD_NODES_FILENAME = "standardnodes.csv"
 HUMAN_JUDGMENTS_FILENAME = "humanjudgments.csv"
 METADATA_FILENAME = "metadata.json"
+
+# in production, we'd want to limit this, but for hackathon purposes
+# we want to make sure everyone doing local dev can reach the API.
+# TODO: switch to whitelist once in production, via instructions at:
+# https://pypi.org/project/django-cors-headers/
+CORS_ORIGIN_ALLOW_ALL = True

--- a/alignmentpro/alignmentpro/urls.py
+++ b/alignmentpro/alignmentpro/urls.py
@@ -26,10 +26,10 @@ from alignmentapp.api import (
 )
 
 router = routers.DefaultRouter()
-router.register(r"document", CurriculumDocumentViewSet, basename="document")
-router.register(r"node", StandardNodeViewSet, basename="node")
-router.register(r"judgment", HumanRelevanceJudgmentViewSet, basename="judgment")
-router.register(r"user", UserViewSet, basename="user")
+router.register(r"document", CurriculumDocumentViewSet)
+router.register(r"node", StandardNodeViewSet)
+router.register(r"judgment", HumanRelevanceJudgmentViewSet)
+router.register(r"user", UserViewSet)
 
 urlpatterns = [
     path("admin/", admin.site.urls),


### PR DESCRIPTION
This should be enough to get started on the UI. You can see the full list of endpoints in the browsable API at: http://127.0.0.1:8000/api/

The most relevant ones for the UI will be:
- GET http://127.0.0.1:8000/api/node/?scheduler=random (get two random nodes to use for the comparison)
- POST http://127.0.0.1:8000/api/judgment/ (to store a human judgment into the database)

You'll need to be logged in via http://127.0.0.1:8000/api-auth/login/?next=/api/

I've added a CORS library that should enable cross-origin requests, so don't worry about ports etc.
