### PR TITLE
Make toolbar absolute to avoid clipping from navigation drawer

### DIFF
--- a/alignmentpro/frontend/App.vue
+++ b/alignmentpro/frontend/App.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app id="app">
-    <v-toolbar app clipped-left>
+    <v-toolbar app clipped-left absolute>
       <v-btn flat icon to="/">
         <v-icon>home</v-icon>
       </v-btn>


### PR DESCRIPTION
Fixes 
![image](https://user-images.githubusercontent.com/7447496/67987563-fdc55d80-fbea-11e9-8517-6d93940ad323.png)
